### PR TITLE
Add support for token auth

### DIFF
--- a/Modules/CloudFlareClearCache/Controllers/ClearCacheController.cs
+++ b/Modules/CloudFlareClearCache/Controllers/ClearCacheController.cs
@@ -171,6 +171,7 @@ namespace Upendo.Modules.CloudFlareClearCache.Controllers
             return (!string.IsNullOrEmpty(model.Config.ApiToken) && 
                     !string.IsNullOrEmpty(model.Config.Email) &&
                     !string.IsNullOrEmpty(model.Config.ZoneID));
+            return (!string.IsNullOrEmpty(model.Config.ApiToken) && !string.IsNullOrEmpty(model.Config.ZoneID));
         }
 
         private PortalSetting GetPortalSetting(int portalId)

--- a/Modules/CloudFlareClearCache/Services/CloudFlareController.cs
+++ b/Modules/CloudFlareClearCache/Services/CloudFlareController.cs
@@ -85,13 +85,21 @@ namespace Upendo.Modules.CloudFlareClearCache.Services
 
         private Dictionary<string, string> GetCustomHeaders(Settings moduleSettings)
         {
-            var newHeaders = new Dictionary<string, string>
+            if (string.IsNullOrEmpty(moduleSettings.Email))
             {
-                {"X-Auth-Key", moduleSettings.ApiToken}, 
-                {"X-Auth-Email", moduleSettings.Email}
-            };
-
-            return newHeaders;
+                return new Dictionary<string, string>
+                {
+                    {"Authorization", string.Concat("Bearer ", moduleSettings.ApiToken)}
+                };
+            }
+            else
+            {
+                return new Dictionary<string, string>
+                {
+                    {"X-Auth-Key", moduleSettings.ApiToken},
+                    {"X-Auth-Email", moduleSettings.Email}
+                };
+            }
         }
 
         private void LogError(Exception exc)


### PR DESCRIPTION
While waiting on an answer for #3 I went ahead and implemented something for our team really quickly to get them up and running. If I've missed something or you prefer a different implementation, please feel free to reject the PR.

I wanted to do the bare minimum to get it up and running, so I am reusing the same ApiToken field for double-duty. If there is an email address, it will use API auth, if it has no email address it will use Token auth. I've also taken out the requirement that Email be filled in to determine if it is ready to use or not.